### PR TITLE
CCP-Module: No Sourcemod prefix

### DIFF
--- a/smbuild
+++ b/smbuild
@@ -4,14 +4,15 @@ Plugin(source='submodules/test/skipcolors_example.sp', deps=['ccprocessor'])
 Plugin(source='submodules/fakename/ccp_fakename.sp', deps=['ccprocessor'])
 Plugin(source='submodules/vipchat/scripting/ccp_vipchat.sp', deps=['ccprocessor'])
 Plugin(source='submodules/indivprefix/scripting/ccp_indprefix.sp', deps=['ccprocessor'])
+Plugin(source='submodules/nosmprefix/ccp_nosm.sp', deps=['ccprocessor'])
 
 Package(name='ccproc-all',
-        plugins=['ccprocessor', 'ccp_test', 'ccp_fakename', 'ccp_vipchat', 'ccp_indprefix', 'skipcolors_example'],
+        plugins=['ccprocessor', 'ccp_test', 'ccp_fakename', 'ccp_vipchat', 'ccp_indprefix', 'skipcolors_example', 'ccp_nosm'],
 )
 
 Package(name='ccproc-release',
         extends=['ccproc-all'],
-        disabled_plugins=['ccp_test', 'ccp_fakename', 'ccp_vipchat', 'ccp_indprefix', 'skipcolors_example'],
+        disabled_plugins=['ccp_test', 'ccp_fakename', 'ccp_vipchat', 'ccp_indprefix', 'skipcolors_example', 'ccp_nosm'],
         filegroups={
             '.': ['LICENSE' , 'README.md'],
         },

--- a/submodules/nosmprefix/ccp_nosm.sp
+++ b/submodules/nosmprefix/ccp_nosm.sp
@@ -6,8 +6,8 @@ public Plugin myinfo =
 {
 	name = "[CCP] No SM prefix",
 	author = "nullent?",
-	description = "Replaces the standard Sourcemod prefix for server messages",
-	version = "1.0",
+	description = "Allows you to replace the standard Sourcemod prefix",
+	version = "1.0.1",
 	url = "discord.gg/ChTyPUG"
 };
 
@@ -18,6 +18,7 @@ char szPrefix[TEAM_LENGTH];
 public void OnPluginStart()
 {
     CreateConVar("ccp_nosm_prefix", "[Valve]", "The new value for the prefix").AddChangeHook(OnCvarChanged);
+    AutoExecConfig(true, "nosm", "ccprocessor");
 }
 
 public void OnMapStart()
@@ -27,12 +28,15 @@ public void OnMapStart()
 
 public void OnCvarChanged(ConVar cvar, const char[] oldVal, const char[] newVal)
 {
+    szPrefix[0] = 0;
+
     if(cvar) cvar.GetString(szPrefix, sizeof(szPrefix));
 }
 
 public bool cc_proc_OnServerMsg(char[] szMessage, int MsgLen)
 {
-    ReplaceStringEx(szMessage, MsgLen, SM_PREFIX, szPrefix, -1, -1, true);
+    if(szPrefix[0])
+        ReplaceStringEx(szMessage, MsgLen, SM_PREFIX, szPrefix, -1, -1, true);
 
     return true;
 }

--- a/submodules/nosmprefix/ccp_nosm.sp
+++ b/submodules/nosmprefix/ccp_nosm.sp
@@ -1,0 +1,39 @@
+#pragma newdecls required
+
+#include ccprocessor
+
+public Plugin myinfo = 
+{
+	name = "[CCP] No SM prefix",
+	author = "nullent?",
+	description = "Replaces the standard Sourcemod prefix for server messages",
+	version = "1.0",
+	url = "discord.gg/ChTyPUG"
+};
+
+#define SM_PREFIX "[SM]"
+
+char szPrefix[TEAM_LENGTH];
+
+public void OnPluginStart()
+{
+    CreateConVar("ccp_nosm_prefix", "[Valve]", "The new value for the prefix").AddChangeHook(OnCvarChanged);
+}
+
+public void OnMapStart()
+{
+    OnCvarChanged(FindConVar("ccp_nosm_prefix"), NULL_STRING, NULL_STRING);
+}
+
+public void OnCvarChanged(ConVar cvar, const char[] oldVal, const char[] newVal)
+{
+    if(cvar) cvar.GetString(szPrefix, sizeof(szPrefix));
+}
+
+public bool cc_proc_OnServerMsg(char[] szMessage, int MsgLen)
+{
+    ReplaceStringEx(szMessage, MsgLen, SM_PREFIX, szPrefix, -1, -1, true);
+
+    return true;
+}
+


### PR DESCRIPTION
Allows you to replace the standard Sourcemod prefix for the chat messages