### PR TITLE
`SayText` message

### DIFF
--- a/scripting/ccprocessor.sp
+++ b/scripting/ccprocessor.sp
@@ -31,7 +31,7 @@ public Plugin myinfo =
     name        = "CCProcessor",
     author      = "nullent?",
     description = "Color chat processor",
-    version     = "2.5.1",
+    version     = "2.5.2",
     url         = "discord.gg/ChTyPUG"
 };
 

--- a/scripting/ccprocessor.sp
+++ b/scripting/ccprocessor.sp
@@ -31,7 +31,7 @@ public Plugin myinfo =
     name        = "CCProcessor",
     author      = "nullent?",
     description = "Color chat processor",
-    version     = "2.4.2",
+    version     = "2.5.0",
     url         = "discord.gg/ChTyPUG"
 };
 
@@ -51,6 +51,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
     umType = GetUserMessageType();
 
     HookUserMessage(GetUserMessageId("TextMsg"), UserMessage_TextMsg, true);
+    HookUserMessage(GetUserMessageId("SayText"), UserMessage_SayText, true);
     HookUserMessage(GetUserMessageId("SayText2"), UserMessage_SayText2, true, SayText2_Completed);
     HookUserMessage(GetUserMessageId("RadioText"), UserMessage_RadioText, true, RadioText_Completed);
 
@@ -75,6 +76,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 }
 
 #include "ccprocessor/ccp_saytext2.sp"
+#include "ccprocessor/ccp_saytext.sp"
 #include "ccprocessor/ccp_textmsg.sp"
 #include "ccprocessor/ccp_radiomsg.sp"
 

--- a/scripting/ccprocessor.sp
+++ b/scripting/ccprocessor.sp
@@ -31,7 +31,7 @@ public Plugin myinfo =
     name        = "CCProcessor",
     author      = "nullent?",
     description = "Color chat processor",
-    version     = "2.5.0",
+    version     = "2.5.1",
     url         = "discord.gg/ChTyPUG"
 };
 

--- a/scripting/ccprocessor/ccp_saytext.sp
+++ b/scripting/ccprocessor/ccp_saytext.sp
@@ -57,16 +57,16 @@ public void SayText_Completed(any data)
     ArrayList arr = view_as<ArrayList>(data);
 
     char szMessage[MESSAGE_LENGTH];
-    netMessage.GetString(eMsg, SZ(szMessage));
+    arr.GetString(eMsg, SZ(szMessage));
 
-    int[] players = new int[netMessage.Get(eCount)];
-    netMessage.GetArray(eArray, players, netMessage.Get(eCount));
+    int[] players = new int[arr.Get(eCount)];
+    arr.GetArray(eArray, players, arr.Get(eCount));
     
     BfWrite message = 
     view_as<BfWrite>(
         StartMessageEx(
-            netMessage.Get(eIdx), players, 
-            netMessage.Get(eCount), 
+            arr.Get(eIdx), players, 
+            arr.Get(eCount), 
             USERMSG_RELIABLE|USERMSG_BLOCKHOOKS
         )
     );

--- a/scripting/ccprocessor/ccp_saytext.sp
+++ b/scripting/ccprocessor/ccp_saytext.sp
@@ -56,7 +56,7 @@ public void SayText_Completed(any data)
 {
     ArrayList arr = view_as<ArrayList>(data);
 
-    char szMessage[MESSAGE_LENGTH];
+    char szMessage[MAX_LENGTH];
     arr.GetString(eMsg, SZ(szMessage));
 
     int[] players = new int[arr.Get(eCount)];

--- a/scripting/ccprocessor/ccp_saytext.sp
+++ b/scripting/ccprocessor/ccp_saytext.sp
@@ -1,0 +1,84 @@
+
+/*
+    This is a personal update for `level-ranks` users, which uses `SayText` for messages from the plugin.
+    The hook allows you to build a message according to the internal patterns of the core.
+*/
+
+public Action UserMessage_SayText(UserMsg msg_id, Handle msg, const int[] players, int playersNum, bool reliable, bool init)
+{
+    if(((!umType) ? BfReadByte(msg) : PbReadInt(msg, "ent_idx")) != 0)
+        return Plugin_Continue;
+
+    static char szName[NAME_LENGTH], szMessage[MESSAGE_LENGTH], szBuffer[MAX_LENGTH];
+    szName = NULL_STRING;
+    szBuffer = NULL_STRING;
+    szMessage = NULL_STRING;
+
+    if(!umType) BfReadString(msg, SZ(szMessage));
+    else PbReadString(msg, "text", SZ(szMessage));
+
+    if(!((!umType) ? view_as<bool>(BfReadByte(msg)) : PbReadBool(msg, "chat")))
+        return Plugin_Continue;
+
+    szName = "CONSOLE";
+        
+    GetMessageByPrototype(
+        eIdx, eMsg_SERVER, eIdx+1, false, SZ(szName), SZ(szMessage), SZ(szBuffer)
+    );
+
+    if(!szMessage[0] || !szBuffer[0])
+        return Plugin_Handled;
+
+    Call_MessageBuilt(eIdx, szBuffer);
+
+    ReplaceColors(SZ(szBuffer), false);
+
+    if(umType)
+    {
+        PbSetString(msg, "text", szBuffer);
+        return Plugin_Continue;
+    }
+
+    {
+        ArrayList arr = new ArrayList(sizeof(szBuffer), 0);
+        arr.Push(msg_id);
+        arr.PushString(szBuffer);
+        arr.PushArray(players, playersNum);
+        arr.Push(playersNum);
+
+        RequestFrame(SayText_Completed, arr);
+    }
+    
+    return Plugin_Handled;
+}
+
+public void SayText_Completed(any data)
+{
+    ArrayList arr = view_as<ArrayList>(data);
+
+    char szMessage[MESSAGE_LENGTH];
+    netMessage.GetString(eMsg, SZ(szMessage));
+
+    int[] players = new int[netMessage.Get(eCount)];
+    netMessage.GetArray(eArray, players, netMessage.Get(eCount));
+    
+    BfWrite message = 
+    view_as<BfWrite>(
+        StartMessageEx(
+            netMessage.Get(eIdx), players, 
+            netMessage.Get(eCount), 
+            USERMSG_RELIABLE|USERMSG_BLOCKHOOKS
+        )
+    );
+
+    if(message && message != INVALID_HANDLE)
+    {
+        message.WriteByte(0);
+        message.WriteString(szMessage);
+        message.WriteByte(true);
+
+        EndMessage();
+    }
+
+    delete arr;
+}

--- a/scripting/ccprocessor/ccp_textmsg.sp
+++ b/scripting/ccprocessor/ccp_textmsg.sp
@@ -62,7 +62,7 @@ public Action UserMessage_TextMsg(UserMsg msg_id, Handle msg, const int[] player
 
 public void TextMsg_Completed(any data)
 {
-    char szMessage[MESSAGE_LENGTH];
+    char szMessage[MAX_LENGTH];
     netMessage.GetString(eMsg, SZ(szMessage));
 
     int[] players = new int[netMessage.Get(eCount)];


### PR DESCRIPTION
This is a personal update for `level-ranks` users, which uses `SayText` for messages from the plugin.
The hook allows you to build a message according to the internal patterns of the core.